### PR TITLE
chore(release): v2.3.1

### DIFF
--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -27,12 +27,12 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - name: Cache .pnpm-store
-        uses: actions/cache@v2.1.5
-        id: pnpm-cache
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+      # - name: Cache .pnpm-store
+      #   uses: actions/cache@v2.1.5
+      #   id: pnpm-cache
+      #   with:
+      #     path: ~/.pnpm-store
+      #     key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
 
       - name: Install pnpm
         run: sudo npm install -g pnpm

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -46,10 +46,10 @@ jobs:
           CI: true
 
       - name: Linting
-        run: pnpx eslint
+        run: pnpm run lint
 
       - name: Type checking
-        run: pnpx tsc
+        run: pnpm run type-check
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -47,7 +47,7 @@ jobs:
         run: pnpx eslint
 
       - name: Type checking
-        run: pnpm run type-check
+        run: pnpx tsc
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -49,7 +49,7 @@ jobs:
         run: pnpx eslint
 
       - name: Type checking
-        run: pnpm run tsc
+        run: pnpm run type-check
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -33,8 +33,6 @@ jobs:
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
 
       - name: Install pnpm
         run: sudo npm install -g pnpm

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -46,10 +46,10 @@ jobs:
           CI: true
 
       - name: Linting
-        run: pnpm run lint
+        run: pnpx eslint
 
       - name: Type checking
-        run: pnpm run type-check
+        run: pnpx tsc
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -49,7 +49,7 @@ jobs:
         run: pnpx eslint
 
       - name: Type checking
-        run: pnpx tsc
+        run: pnpm run tsc
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -27,12 +27,12 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - name: Cache .pnpm-store
-        uses: actions/cache@v2.1.5
-        id: pnpm-cache
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+      # - name: Cache .pnpm-store
+      #   uses: actions/cache@v2.1.5
+      #   id: pnpm-cache
+      #   with:
+      #     path: ~/.pnpm-store
+      #     key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
 
       - name: Install pnpm
         run: sudo npm install -g pnpm

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -46,10 +46,10 @@ jobs:
           CI: true
 
       - name: Linting
-        run: pnpx eslint
+        run: pnpm run lint
 
       - name: Type checking
-        run: pnpx tsc
+        run: pnpm run type-check
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -47,7 +47,7 @@ jobs:
         run: pnpx eslint
 
       - name: Type checking
-        run: pnpm run type-check
+        run: pnpx tsc
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -49,7 +49,7 @@ jobs:
         run: pnpx eslint
 
       - name: Type checking
-        run: pnpm run tsc
+        run: pnpm run type-check
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -33,8 +33,6 @@ jobs:
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
 
       - name: Install pnpm
         run: sudo npm install -g pnpm

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -46,10 +46,10 @@ jobs:
           CI: true
 
       - name: Linting
-        run: pnpm run lint
+        run: pnpx eslint
 
       - name: Type checking
-        run: pnpm run type-check
+        run: pnpx tsc
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -49,7 +49,7 @@ jobs:
         run: pnpx eslint
 
       - name: Type checking
-        run: pnpx tsc
+        run: pnpm run tsc
 
       - name: Build
         run: pnpm build

--- a/data/blog/2021/esbuild-pnpm-and-tailwind-in-phoenix.mdx
+++ b/data/blog/2021/esbuild-pnpm-and-tailwind-in-phoenix.mdx
@@ -1,7 +1,7 @@
 ---
 archived: false
 createdAt: 06/10/2021
-description: Refactoring the generated client-side build in Phoenix applications to use esbuild, pnpm, and tailwindcss.
+description: Refactoring the generated client-side build in Phoenix applications to use Esbuild, PNPM, and TailwindCSS.
 keywords:
   - elixir
   - esbuild
@@ -10,7 +10,7 @@ keywords:
   - phoenix liveview
   - tailwindcss
   - webpack
-published: false
+published: true
 tags:
   - elixir
   - live-view
@@ -20,6 +20,8 @@ title: Esbuild, PNPM, & Tailwind in Phoenix
 ---
 
 import { Signature } from '../components/MDXComponents.tsx'
+
+In the last two months between protests in Colombia and my wife and I running to get things Colombia required for my visa at the last minute I've been doing a lot of reading and dives into source code when it comes to Elixir and Phoenix. I want this to be my new stack and really would just like to pivot my career into the stack but maybe even more so embedded software with the [Nerves Project](https://www.nerves-project.org/). Our raspberry-pi module's arrived this week so plan on seeing some elixir-based raspberry-pi posts coming soon. This post is about my experience in customizing the client-side JavaScript code Phoenix ships with so that the build process makes use of the lightning fast esbuild bundler and tailwindcss with the new just-in-time mode enabled.
 
 ## Bootstrapping a Phoenix Application
 
@@ -31,7 +33,7 @@ mix phx.new my_phoenix_app --live
 
 ## Switching to pnpm
 
-I recently moved to using [pnpm](https://pnpm.io/) instead of [yarn](https://yarnpkg.com/), you can read about that [here](https://codybrunner.dev/blog/2021/migrating-from-yarn-to-pnpm). By default Phoenix ships using `npm` as the package manager for JavaScript dependencies. To make the switch inside the app to the `pnpm` we will need to update a few files.
+I recently moved to using [pnpm](https://pnpm.io/) instead of [yarn](https://yarnpkg.com/), you can read about that [here](https://codybrunner.dev/blog/2021/migrating-from-yarn-to-pnpm). By default Phoenix ships using `npm` as the package manager for JavaScript dependencies. To make the switch inside the app to the `pnpm` we will need to add one file and update a few others:
 
 ```shell
 touch pnpm-workspace.yaml
@@ -49,6 +51,8 @@ By telling `pnpm` that the `assets` directory is a workspace when running comman
 ```
 
 The next thing we will need to do is update the aliased commands in the `mix.exs` file to reference the usage of `pnpm`:
+
+> **Note**: If you are shipping your code in a docker container you can keep the line in your `.dockerignore` file as `assets/node_modules/`.
 
 ```diff:mix.exs
 defmodule MyPhoenixApp.MixProject do
@@ -242,6 +246,7 @@ module.exports = (env, options) => {
 +       new ESBuildMinifyPlugin({
 +         target: 'es2015',
 +       }),
++         css: true,
 +     ],
 +   },
     output: {
@@ -266,8 +271,12 @@ touch assets/postcss.config.js assets/tailwind.config.js
 ```
 
 ```javascript:assets/postcss.config.js
+We will add a `postcss.config.js`, `tailwind.config.js`, add the tailwind base CSS to our `app.scss` file, and finally we will update our webpack config to use the `postcss-loader` in the pipeline of loaders for our CSS files:
+
 module.exports = {
   plugins: [
+  // Order of plugins is important.
+  // autoprefixer should always be last.
     'postcss-import',
     'tailwindcss',
     'postcss-preset-env',
@@ -280,6 +289,8 @@ module.exports = {
 module.exports = {
   mode: 'jit',
   purge: [
+  // These are the files we will want tailwind to watch for changes in
+  // and purge the old CSS for the new.
     '../lib/my_phoenix_app_web/templates/**/*',
     '../lib/my_phoenix_app_web/views/**/*',
     '../lib/my_phoenix_app_web/live/**/*',
@@ -293,6 +304,7 @@ module.exports = {
 @import 'tailwindcss/utilities';
 
 @import './phoenix.css';
+// Any custom CSS or custom Tailwind-related CSS must be below the above imports.
 ```
 
 ```diff:assets/webpack.config.js
@@ -332,7 +344,7 @@ module.exports = (env, options) => {
       minimizer: [
         new ESBuildMinifyPlugin({
           target: 'es2015',
-+         css: true,
+          css: true,
         }),
       ],
     },
@@ -350,6 +362,8 @@ module.exports = (env, options) => {
 ```
 
 ```json:assets/package.json
+Now on to the scripts that we will need to add back. Without specifically the `watch` script if we are to run `mix start (mix phx.server)` our application will fail to start because the script does not exist.
+
 {
   "scripts": {
     "build": "NODE_ENV=production TAILWIND_MODE=build webpack --mode production",
@@ -362,7 +376,31 @@ module.exports = (env, options) => {
 
 ## Deploying the new build configuration to fly.io
 
+This is actually where things got tricky with Tailwind's new "just-in-time" mode. If you remove the `TAILWIND_MODE` segments of the scripts above what you will end up with is tailwind not swapping out the old utilities declared on an element for the new ones on save. So you will see no changes in the browser. Furthermore I found that when building a production build tailwind would ship all of tailwind in the bundle however any utilities being referenced were not present. See belows example:
+
+```html
+<!-- Development Source-->
+<h1 class="text-green-500 text-xl">Hello Phoenix LiveView</h1>
+<style>
+  .text-green-500 {
+    --tw-text-opacity: 1 !important;
+    color: rgba(34, 197, 94, var(--tw-text-opacity)) !important;
+  }
+  .text-xl {
+    --tw-text-opacity: 1 !important;
+    color: rgba(34, 197, 94, var(--tw-text-opacity)) !important;
+  }
+</style>
+<!-- Build Source -->
+<h1 class="text-green-500 text-xl">Hello Phoenix LiveView</h1>
+<style></style>
+```
+
+It turns out that this has to do with how tailwind is operating in specific environments under the hood.
+
 ```diff:Dockerfile
+I came across [fly.io](https://fly.io/) a few weeks ago and walked through there example phoenix app for deploying to their platform and I'm so impressed with them. They have become my go to for hosting when it comes to elixir and phoenix. You can check out that example app [here](https://fly.io/docs/getting-started/elixir/) if you are interested in trying them out.
+
 FROM hexpm/elixir:1.11.2-erlang-23.3.2-alpine-3.13.3 AS build
 
 # Yes we will still install npm, work with me here.
@@ -431,7 +469,9 @@ ENV SECRET_KEY_BASE=nokey
 ENV PORT=4000
 
 CMD ["bin/my_phoenix_app", "start"]
-
 ```
 
 <Signature>~ Cody 🚀</Signature>
+And that's it! We now have crazy fast installation and dependency management with
+`pnpm`. We have an even faster client-side build thanks to `esbuild`. We have "just-in-time"
+support with `tailwind`! 🎉

--- a/data/blog/2021/esbuild-pnpm-and-tailwind-in-phoenix.mdx
+++ b/data/blog/2021/esbuild-pnpm-and-tailwind-in-phoenix.mdx
@@ -1,0 +1,437 @@
+---
+archived: false
+createdAt: 06/10/2021
+description: Refactoring the generated client-side build in Phoenix applications to use esbuild, pnpm, and tailwindcss.
+keywords:
+  - elixir
+  - esbuild
+  - just-in-time
+  - phoenix
+  - phoenix liveview
+  - tailwindcss
+  - webpack
+published: false
+tags:
+  - elixir
+  - live-view
+  - phoenix
+  - tailwindcss
+title: Esbuild, PNPM, & Tailwind in Phoenix
+---
+
+import { Signature } from '../components/MDXComponents.tsx'
+
+## Bootstrapping a Phoenix Application
+
+What we are doing here will work for regular Phoenix applications or a LiveView application, but for this post I will be doing a LiveView application.
+
+```shell
+mix phx.new my_phoenix_app --live
+```
+
+## Switching to pnpm
+
+I recently moved to using [pnpm](https://pnpm.io/) instead of [yarn](https://yarnpkg.com/), you can read about that [here](https://codybrunner.dev/blog/2021/migrating-from-yarn-to-pnpm). By default Phoenix ships using `npm` as the package manager for JavaScript dependencies. To make the switch inside the app to the `pnpm` we will need to update a few files.
+
+```shell
+touch pnpm-workspace.yaml
+```
+
+```yml:pnpm-workspace.yaml
+packages:
+  - 'assets/'
+```
+
+By telling `pnpm` that the `assets` directory is a workspace when running commands at the root level such as `pnpm install` it will look into the `assets` directory at the `package.json` and reach out to the registry for the code. A `pnpm-lock.yaml` will be generated at the top-level this will also move where the `node_modules` directory to the top-level so we need to update the `.gitignore` file to not commit the JavaScript dependencies source code.
+
+```diff:.gitignore
++ /node_modules/
+```
+
+The next thing we will need to do is update the aliased commands in the `mix.exs` file to reference the usage of `pnpm`:
+
+```diff:mix.exs
+defmodule MyPhoenixApp.MixProject do
+...
+
+defp aliases do
+  [
+-   setup: ["deps.get", "ecto.setup", "cmd npm install  --prefix assets"],
++   setup: ["deps.get", "ecto.setup", "cmd pnpm install"],
+    "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
+    "ecto.reset": ["ecto.drop", "ecto.setup"],
+    test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"],
++   start: ["phx.server"]
+  ]
+  end
+end
+```
+
+And the final change we will need to make, at least to elixir based code is to update the `dev.exs` specifically the `watchers` section of the config to reference what will be the new command for executing the client in watch mode:
+
+```diff:config/dev.exs
+import Config
+
+config :my_phoenix_app, MyPhoenixAppWeb.Endpoint,
+  http: [port: 4000],
+  debug_errors: true,
+  code_reloader: true,
+  check_origin: false,
+  watchers: [
+-    node: [
+-      "node_modules/webpack/bin/webpack.js",
+-      "--mode",
+-      "development",
+-      "--watch-stdin",
+-      cd: Path.expand("../assets", __DIR__)
+-    ]
++    pnpm: [
++     "run",
++     "watch",
++     cd: Path.expand("../assets", __DIR__)
++    ]
+  ]
+```
+
+## Cleaning out the client-side code
+
+To make this a little easier I removed the `devDependencies` and `scripts` from the `package.json`. I also removed the `package-lock.json` as well as `node_modules`. The last thing I did before getting started was gutting the generated `webpack.config.js`
+
+```diff:package.json
+{
+  "repository": {},
+  "description": " ",
+  "license": "MIT",
+- "scripts": {
+-   "build": "NODE_ENV=production TAILWIND_MODE=build webpack --mode production",
+-   "dev": "NODE_ENV=development TAILWIND_MODE=build webpack --mode development --no-color",
+-   "preinstall": "npx only-allow pnpm",
+-   "watch": "NODE_ENV=development TAILWIND_MODE=watch webpack --mode development --no-color --watch"
+- },
++ "scripts": {},
+  "dependencies": {
+    "phoenix": "file:../deps/phoenix",
+    "phoenix_html": "file:../deps/phoenix_html",
+    "phoenix_live_view": "file:../deps/phoenix_live_view",
+    "topbar": "^0.1.4"
+  },
+- "devDependencies": {
+-   "autoprefixer": "~10.2.6",
+-   "copy-webpack-plugin": "~9.0.0",
+-   "css-loader": "~5.2.6",
+-   "esbuild-loader": "~2.13.1",
+-   "glob": "~7.1.7",
+-   "mini-css-extract-plugin": "~1.6.0",
+-   "postcss": "~8.3.0",
+-   "postcss-import": "~14.0.2",
+-   "postcss-loader": "~5.3.0",
+-   "postcss-preset-env": "~6.7.0",
+-   "sass": "~1.34.1",
+-   "sass-loader": "~12.0.0",
+-   "tailwindcss": "~2.1.4",
+-   "webpack": "~5.38.1",
+-   "webpack-cli": "~4.7.0"
+-}
++ "devDependencies": {}
+}
+```
+
+```diff:webpack.config.js
+const path = require('path');
+const glob = require('glob');
+- const HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
+- const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+- const TerserPlugin = require('terser-webpack-plugin');
+- const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
+- const CopyWebpackPlugin = require('copy-webpack-plugin');
+
+module.exports = (env, options) => {
+  const devMode = options.mode !== 'production';
+
+  return {
+-    optimization: {
+-      minimizer: [
+-        new TerserPlugin({ cache: true, parallel: true, sourceMap: devMode }),
+-        new OptimizeCSSAssetsPlugin({})
+-      ]
+-    },
+    entry: {
+      'app': glob.sync('./vendor/**/*.js').concat(['./js/app.js'])
+    },
+    output: {
+      filename: '[name].js',
+      path: path.resolve(__dirname, '../priv/static/js'),
+      publicPath: '/js/'
+    },
+    devtool: devMode ? 'eval-cheap-module-source-map' : undefined,
+    module: {
+-     rules: [
+-       {
+-         test: /\.js$/,
+-         exclude: /node_modules/,
+-         use: {
+-           loader: 'babel-loader'
+-         }
+-       },
+-       {
+-         test: /\.[s]?css$/,
+-         use: [
+-           MiniCssExtractPlugin.loader,
+-           'css-loader',
+-           'sass-loader',
+-         ],
+-       }
+-     ]
++    rules: []
+    },
+-   plugins: [
+-     new MiniCssExtractPlugin({ filename: '../css/app.css' }),
+-     new CopyWebpackPlugin([{ from: 'static/', to: '../' }])
+-   ]
+-   .concat(devMode ? [new HardSourceWebpackPlugin()] : [])
++   plugins: []
+  }
+};
+```
+
+## Switching to Esbuild
+
+I've become a big fan of this project, [esbuild](https://esbuild.github.io) is a JavaScript bundler written in Golang and is lighting fast! It's pretty easy to switch to when using Webpack as well because of the [esbuild-loader](https://github.com/privatenumber/esbuild-loader). We will add back some of the dependencies that shipped with Phoenix but we will use the latest versions including `webpack@5`.
+
+```shell
+pnpm add -D copy-webpack-plugin css-loader esbuild-loader glob mini-css-extract-plugin sass sass-loader webpack webpack-cli
+```
+
+```diff:assets/webpack.config.js
+- const path = require('path')
+- const glob = require('glob')
++ const { resolve } = require('path')
++ const CopyWebpackPlugin = require('copy-webpack-plugin')
++ const { ESBuildMinifyPlugin } = require('esbuild-loader')
++ const { sync } = require('glob')
++ const MiniCssExtractPlugin = require('mini-css-extract-plugin')
+
+module.exports = (env, options) => {
+  const devMode = options.mode !== 'production'
+
+  return {
+    devtool: devMode ? 'eval-cheap-module-source-map' : undefined,
+    entry: {
+      app: sync('./vendor/**/*.js').concat(['./js/app.js']),
+    },
+    module: {
+-     rules: [],
++     rules: [
++       {
++         exclude: /node_modules/,
++         loader: 'esbuild-loader',
++         test: /\.js$/,
++       },
++       {
++         test: /\.[s]?css$/,
++         use: [
++           MiniCssExtractPlugin.loader,
++           'css-loader',
++           'sass-loader',
++         ],
++       },
++     ],
+    },
++   optimization: {
++     minimizer: [
++       new ESBuildMinifyPlugin({
++         target: 'es2015',
++       }),
++     ],
++   },
+    output: {
+      filename: '[name].js',
+      path: resolve(__dirname, '../priv/static/js'),
+      publicPath: '/js/',
+    },
+-   plugins: [],
++   plugins: [
++     new MiniCssExtractPlugin({ filename: '../css/app.css' }),
++     new CopyWebpackPlugin({ patterns: [{ from: 'static/', to: '../' }] }),
++   ],
+  }
+}
+```
+
+## Adding Support for TailwindCSS & Just-In-Time Mode
+
+```shell
+pnpm add -D autoprefixer postcss postcss-import postcss-loader postcss-preset-env tailwindcss
+touch assets/postcss.config.js assets/tailwind.config.js
+```
+
+```javascript:assets/postcss.config.js
+module.exports = {
+  plugins: [
+    'postcss-import',
+    'tailwindcss',
+    'postcss-preset-env',
+    'autoprefixer',
+  ],
+}
+```
+
+```javascript:assets/tailwind.config.js
+module.exports = {
+  mode: 'jit',
+  purge: [
+    '../lib/my_phoenix_app_web/templates/**/*',
+    '../lib/my_phoenix_app_web/views/**/*',
+    '../lib/my_phoenix_app_web/live/**/*',
+  ],
+}
+```
+
+```scss:assets/css/app.scss
+@import 'tailwindcss/base';
+@import 'tailwindcss/components';
+@import 'tailwindcss/utilities';
+
+@import './phoenix.css';
+```
+
+```diff:assets/webpack.config.js
+const { resolve } = require('path')
+const CopyWebpackPlugin = require('copy-webpack-plugin')
+const { ESBuildMinifyPlugin } = require('esbuild-loader')
+const { sync } = require('glob')
+const MiniCssExtractPlugin = require('mini-css-extract-plugin')
+
+module.exports = (env, options) => {
+  const devMode = options.mode !== 'production'
+
+  return {
+    devtool: devMode ? 'eval-cheap-module-source-map' : undefined,
+    entry: {
+      app: sync('./vendor/**/*.js').concat(['./js/app.js']),
+    },
+    module: {
+      rules: [
+        {
+          exclude: /node_modules/,
+          loader: 'esbuild-loader',
+          test: /\.js$/,
+        },
+        {
+          test: /\.[s]?css$/,
+          use: [
+            MiniCssExtractPlugin.loader,
+            'css-loader',
++           'postcss-loader',
+            'sass-loader',
+          ],
+        },
+      ],
+    },
+    optimization: {
+      minimizer: [
+        new ESBuildMinifyPlugin({
+          target: 'es2015',
++         css: true,
+        }),
+      ],
+    },
+    output: {
+      filename: '[name].js',
+      path: resolve(__dirname, '../priv/static/js'),
+      publicPath: '/js/',
+    },
+    plugins: [
+      new MiniCssExtractPlugin({ filename: '../css/app.css' }),
+      new CopyWebpackPlugin({ patterns: [{ from: 'static/', to: '../' }] }),
+    ],
+  }
+}
+```
+
+```json:assets/package.json
+{
+  "scripts": {
+    "build": "NODE_ENV=production TAILWIND_MODE=build webpack --mode production",
+    "dev": "NODE_ENV=development TAILWIND_MODE=build webpack --mode development --no-color",
+    "preinstall": "npx only-allow pnpm",
+    "watch": "NODE_ENV=development TAILWIND_MODE=watch webpack --mode development --no-color --watch"
+  },
+}
+```
+
+## Deploying the new build configuration to fly.io
+
+```diff:Dockerfile
+FROM hexpm/elixir:1.11.2-erlang-23.3.2-alpine-3.13.3 AS build
+
+# Yes we will still install npm, work with me here.
+RUN apk add --no-cache build-base npm
+
+WORKDIR /app
+
+RUN mix local.hex --force && \
+    mix local.rebar --force
+
++ # On the pnpm docs they show that you can install pnpm using npm!
++ # You could also use the curl script on the website as well.
++ # https://pnpm.io/installation
++ RUN npm install -g pnpm
+
+ENV MIX_ENV=prod
+ENV SECRET_KEY_BASE=nokey
+
+COPY mix.exs mix.lock ./
+COPY config config
+
+RUN mix deps.get --only prod && \
+    mix deps.compile
+
+- COPY assets/package.json assets/package-lock.json ./assets/
+- RUN npm --prefix ./assets ci --progress=false --no-audit --loglevel=error
++ COPY assets/package.json ./assets/
++ RUN cd assets && pnpm install
+
+COPY priv priv
+COPY assets assets
+
+# NOTE: If using TailwindCSS, it uses a special "purge" step and that requires
+# the code in `lib` to see what is being used. Uncomment that here before
+# running the npm deploy script if that's the case.
+- # COPY lib lib
++ COPY lib lib
+
+# build assets
+- RUN npm run --prefix ./assets deploy
++ RUN cd assets && pnpm run build
+RUN mix phx.digest
+
+- # copy source here if not using TailwindCSS
+- COPY lib lib
+
+# compile and build release
+COPY rel rel
+RUN mix do compile, release
+
+# prepare release docker image
+FROM alpine:3.13.3 AS app
+RUN apk add --no-cache openssl ncurses-libs
+
+WORKDIR /app
+
+RUN chown nobody:nobody /app
+
+USER nobody:nobody
+
+COPY --from=build --chown=nobody:nobody /app/_build/prod/rel/my_phoenix_app ./
+
+ENV HOME=/app
+ENV MIX_ENV=prod
+ENV SECRET_KEY_BASE=nokey
+ENV PORT=4000
+
+CMD ["bin/my_phoenix_app", "start"]
+
+```
+
+<Signature>~ Cody 🚀</Signature>

--- a/data/blog/archive/2017/automating-with-circleci.mdx
+++ b/data/blog/archive/2017/automating-with-circleci.mdx
@@ -6,7 +6,7 @@ keywords:
   - continuous integration
   - continuous deployment
   - CircleCi
-  - command-line
+  - cli
   - now-cli
   - Zeit
   - deploying
@@ -14,7 +14,7 @@ keywords:
 published: true
 tags:
   - ci/cd
-  - command-line
+  - cli
   - deployment
   - hosting
 title: Automating with CircleCi 2.0

--- a/data/blog/archive/2017/deploying-with-now.mdx
+++ b/data/blog/archive/2017/deploying-with-now.mdx
@@ -5,14 +5,14 @@ description: How to deploy with Zeit's Now platform.
 keywords:
   - now-cli
   - Zeit
-  - command-line
+  - cli
   - JavaScript
   - Docker
   - deployments
   - hosting
 published: true
 tags:
-  - command-line
+  - cli
   - deployment
   - hosting
   - javascript

--- a/data/blog/archive/2017/rewriting-my-site-with-hugo.mdx
+++ b/data/blog/archive/2017/rewriting-my-site-with-hugo.mdx
@@ -10,7 +10,7 @@ keywords:
   - Zeit
 published: true
 tags:
-  - command-line
+  - cli
   - hugo
 title: Rewriting my site with Hugo
 ---

--- a/data/blog/archive/2017/up-and-running-with-iterm-and-zsh.mdx
+++ b/data/blog/archive/2017/up-and-running-with-iterm-and-zsh.mdx
@@ -7,10 +7,10 @@ keywords:
   - ZSH
   - VSCode
   - powerlevel9k
-  - command-line
+  - cli
 published: true
 tags:
-  - command-line
+  - cli
   - iterm2
   - vscode
   - zsh

--- a/data/blog/archive/2018/getting-started-with-python3.mdx
+++ b/data/blog/archive/2018/getting-started-with-python3.mdx
@@ -9,7 +9,7 @@ keywords:
   - PDX Code Guild
 published: true
 tags:
-  - command-line
+  - cli
   - python
   - vscode
 title: Getting Started with Python3

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -39,7 +39,7 @@ export const getStaticProps: GetStaticProps<Props> = async () => {
     return {
       props: {
         // Give the client the 3 latest posts.
-        posts: filterPosts(posts, p => !p.frontMatter.archived).slice(-3),
+        posts: filterPosts(posts, p => !p.frontMatter.archived).slice(-5),
       },
     }
   } catch (error) {


### PR DESCRIPTION
## What does this PR do?

- adds post about integrating `esbuild`, `pnpm`, and `tailwindcss` into a `phoenix` application.
- removes the caching step for `pnpm` in the workflows, will revisit at another time to figure out what the problem is.