### PR TITLE
chore(release): v4.2.0

### DIFF
--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -1,4 +1,3 @@
-import { stringify } from 'querystring'
 import { QueryFunctionContext } from 'react-query'
 
 import {
@@ -40,6 +39,10 @@ export async function fetchNowPlaying(
  */
 
 async function getAccessToken(): Promise<AccessTokenResponse> {
+  const params = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: process.env.SPOTIFY_REFRESH_TOKEN!,
+  })
   const response = await fetch(spotify.TOKEN, {
     method: 'POST',
     headers: {
@@ -48,10 +51,7 @@ async function getAccessToken(): Promise<AccessTokenResponse> {
       ).toString('base64')}`,
       'Content-Type': 'application/x-www-form-urlencoded',
     },
-    body: stringify({
-      grant_type: 'refresh_token',
-      refresh_token: process.env.SPOTIFY_REFRESH_TOKEN,
-    }),
+    body: params.toString(),
   })
 
   return await response.json()

--- a/package.json
+++ b/package.json
@@ -12,10 +12,6 @@
     "url": "https://github.com/rockchalkwushock/codybrunner.dev.git"
   },
   "license": "MIT",
-  "engines": {
-    "node": ">=14",
-    "pnpm": ">=6"
-  },
   "scripts": {
     "analyze": "ANALYZE=true yarn build",
     "build": "next build && next-sitemap",
@@ -29,7 +25,6 @@
   },
   "dependencies": {
     "@appointlet/appointlet.js": "~3.0.6",
-    "@mapbox/rehype-prism": "~0.7.0",
     "@tailwindcss/typography": "~0.4.1",
     "@tryghost/content-api": "~1.5.10",
     "@tryghost/helpers": "~1.1.49",
@@ -47,6 +42,7 @@
     "react-share": "~4.4.0",
     "reading-time": "~1.3.0",
     "rehype-autolink-headings": "~5.1.0",
+    "rehype-prism-plus": "~0.0.4",
     "rehype-slug": "~4.0.1",
     "sass": "~1.36.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,6 @@ specifiers:
   '@appointlet/appointlet.js': ~3.0.6
   '@commitlint/cli': ~13.1.0
   '@commitlint/config-conventional': ~13.1.0
-  '@mapbox/rehype-prism': ~0.7.0
   '@next/bundle-analyzer': ~11.0.1
   '@savvywombat/tailwindcss-grid-areas': ~1.3.2
   '@tailwindcss/typography': ~0.4.1
@@ -44,6 +43,7 @@ specifiers:
   reading-time: ~1.3.0
   rehype: ~11.0.0
   rehype-autolink-headings: ~5.1.0
+  rehype-prism-plus: ~0.0.4
   rehype-slug: ~4.0.1
   sass: ~1.36.0
   tailwindcss: ~2.2.7
@@ -51,7 +51,6 @@ specifiers:
 
 dependencies:
   '@appointlet/appointlet.js': 3.0.6
-  '@mapbox/rehype-prism': 0.7.0
   '@tailwindcss/typography': 0.4.1_tailwindcss@2.2.7
   '@tryghost/content-api': 1.5.10
   '@tryghost/helpers': 1.1.49
@@ -69,6 +68,7 @@ dependencies:
   react-share: 4.4.0_react@17.0.2
   reading-time: 1.3.0
   rehype-autolink-headings: 5.1.0
+  rehype-prism-plus: 0.0.4
   rehype-slug: 4.0.1
   sass: 1.36.0
 
@@ -522,18 +522,6 @@ packages:
       }
     dev: true
 
-  /@mapbox/rehype-prism/0.7.0:
-    resolution:
-      {
-        integrity: sha512-zSG46selA6v+3THhCatTyOt9DuTzxTIVTxTbcj15kFmxPDtjzZ5VoFVCLZfjWFouYa9PiXxcbMLLhJoVzCxh9w==,
-      }
-    engines: { node: '>=10' }
-    dependencies:
-      hast-util-to-string: 1.0.4
-      refractor: 3.4.0
-      unist-util-visit: 2.0.3
-    dev: false
-
   /@next/bundle-analyzer/11.0.1:
     resolution:
       {
@@ -751,6 +739,13 @@ packages:
         integrity: sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==,
       }
     dev: true
+
+  /@types/prismjs/1.16.6:
+    resolution:
+      {
+        integrity: sha512-dTvnamRITNqNkqhlBd235kZl3KfVJQQoT5jkXeiWSBK7i4/TLKBNLV0S1wOt8gy4E2TY722KLtdmv2xc6+Wevg==,
+      }
+    dev: false
 
   /@types/prop-types/15.7.4:
     resolution:
@@ -1653,18 +1648,26 @@ packages:
       {
         integrity: sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==,
       }
+    dev: true
 
-  /character-entities/1.2.4:
+  /character-entities-legacy/2.0.0:
     resolution:
       {
-        integrity: sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==,
+        integrity: sha512-YwaEtEvWLpFa6Wh3uVLrvirA/ahr9fki/NUd/Bd4OR6EdJ8D22hovYQEOUCBfQfcqnC4IAMGMsHXY1eXgL4ZZA==,
       }
     dev: false
 
-  /character-reference-invalid/1.1.4:
+  /character-entities/2.0.0:
     resolution:
       {
-        integrity: sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==,
+        integrity: sha512-oHqMj3eAuJ77/P5PaIRcqk+C3hdfNwyCD2DAUcD5gyXkegAuF2USC40CEqPscDk4I8FRGMTojGJQkXDsN5QlJA==,
+      }
+    dev: false
+
+  /character-reference-invalid/2.0.0:
+    resolution:
+      {
+        integrity: sha512-pE3Z15lLRxDzWJy7bBHBopRwfI20sbrMVLQTC7xsPglCHf4Wv1e167OgYAFP78co2XlhojDyAqA+IAJse27//g==,
       }
     dev: false
 
@@ -1845,6 +1848,14 @@ packages:
       {
         integrity: sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==,
       }
+    dev: true
+
+  /comma-separated-tokens/2.0.2:
+    resolution:
+      {
+        integrity: sha512-G5yTt3KQN4Yn7Yk4ed73hlZ1evrFKXeUW3086p3PRFNp7m2vIjI6Pg+Kgb+oyzhd9F2qdcoj67+y3SdxL5XWsg==,
+      }
+    dev: false
 
   /commander/6.2.1:
     resolution:
@@ -3527,6 +3538,16 @@ packages:
       {
         integrity: sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==,
       }
+    dev: true
+
+  /hast-util-parse-selector/3.1.0:
+    resolution:
+      {
+        integrity: sha512-AyjlI2pTAZEOeu7GeBPZhROx0RHBnydkQIXlhnFzDi0qfXTmGUWoCYZtomHbrdrheV4VFUlPcfJ6LMF5T6sQzg==,
+      }
+    dependencies:
+      '@types/hast': 2.3.1
+    dev: false
 
   /hast-util-to-html/7.1.3:
     resolution:
@@ -3571,6 +3592,20 @@ packages:
       hast-util-parse-selector: 2.2.5
       property-information: 5.6.0
       space-separated-tokens: 1.1.5
+    dev: true
+
+  /hastscript/7.0.2:
+    resolution:
+      {
+        integrity: sha512-uA8ooUY4ipaBvKcMuPehTAB/YfFLSSzCwFSwT6ltJbocFUKH/GDHLN+tflq7lSRf9H86uOuxOFkh1KgIy3Gg2g==,
+      }
+    dependencies:
+      '@types/hast': 2.3.1
+      comma-separated-tokens: 2.0.2
+      hast-util-parse-selector: 3.1.0
+      property-information: 6.0.1
+      space-separated-tokens: 2.0.1
+    dev: false
 
   /he/1.2.0:
     resolution:
@@ -3834,21 +3869,21 @@ packages:
       side-channel: 1.0.4
     dev: true
 
-  /is-alphabetical/1.0.4:
+  /is-alphabetical/2.0.0:
     resolution:
       {
-        integrity: sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==,
+        integrity: sha512-5OV8Toyq3oh4eq6sbWTYzlGdnMT/DPI5I0zxUBxjiigQsZycpkKF3kskkao3JyYGuYDHvhgJF+DrjMQp9SX86w==,
       }
     dev: false
 
-  /is-alphanumerical/1.0.4:
+  /is-alphanumerical/2.0.0:
     resolution:
       {
-        integrity: sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==,
+        integrity: sha512-t+2GlJ+hO9yagJ+jU3+HSh80VKvz/3cG2cxbGGm4S0hjKuhWQXgPVUVOZz3tqZzMjhmphZ+1TIJTlRZRoe6GCQ==,
       }
     dependencies:
-      is-alphabetical: 1.0.4
-      is-decimal: 1.0.4
+      is-alphabetical: 2.0.0
+      is-decimal: 2.0.0
     dev: false
 
   /is-arguments/1.1.0:
@@ -3936,10 +3971,10 @@ packages:
       }
     engines: { node: '>= 0.4' }
 
-  /is-decimal/1.0.4:
+  /is-decimal/2.0.0:
     resolution:
       {
-        integrity: sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==,
+        integrity: sha512-QfrfjQV0LjoWQ1K1XSoEZkTAzSa14RKVMa5zg3SdAfzEmQzRM4+tbSFWb78creCeA9rNBzaZal92opi1TwPWZw==,
       }
     dev: false
 
@@ -3977,10 +4012,10 @@ packages:
     dependencies:
       is-extglob: 2.1.1
 
-  /is-hexadecimal/1.0.4:
+  /is-hexadecimal/2.0.0:
     resolution:
       {
-        integrity: sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==,
+        integrity: sha512-vGOtYkiaxwIiR0+Ng/zNId+ZZehGfINwTzdrDqc6iubbnQWhnPuYymOzOKUDqa2cSl59yHnEh2h6MvRLQsyNug==,
       }
     dev: false
 
@@ -5224,18 +5259,18 @@ packages:
       safe-buffer: 5.2.1
     dev: false
 
-  /parse-entities/2.0.0:
+  /parse-entities/3.0.0:
     resolution:
       {
-        integrity: sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==,
+        integrity: sha512-AJlcIFDNPEP33KyJLguv0xJc83BNvjxwpuUIcetyXUsLpVXAUCePJ5kIoYtEN2R1ac0cYaRu/vk9dVFkewHQhQ==,
       }
     dependencies:
-      character-entities: 1.2.4
-      character-entities-legacy: 1.1.4
-      character-reference-invalid: 1.1.4
-      is-alphanumerical: 1.0.4
-      is-decimal: 1.0.4
-      is-hexadecimal: 1.0.4
+      character-entities: 2.0.0
+      character-entities-legacy: 2.0.0
+      character-reference-invalid: 2.0.0
+      is-alphanumerical: 2.0.0
+      is-decimal: 2.0.0
+      is-hexadecimal: 2.0.0
     dev: false
 
   /parse-json/4.0.0:
@@ -5258,6 +5293,13 @@ packages:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.1.6
     dev: true
+
+  /parse-numeric-range/1.2.0:
+    resolution:
+      {
+        integrity: sha512-1q2tXpAOplPxcl8vrIGPWz1dJxxfmdRkCFcpxxMBerDnGuuHalOWF/xj9L8Nn5XoTUoB/6F0CeQBp2fMgkOYFg==,
+      }
+    dev: false
 
   /parse-passwd/1.0.0:
     resolution: { integrity: sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY= }
@@ -5992,6 +6034,14 @@ packages:
       }
     dependencies:
       xtend: 4.0.2
+    dev: true
+
+  /property-information/6.0.1:
+    resolution:
+      {
+        integrity: sha512-F4WUUAF7fMeF4/JUFHNBWDaKDXi2jbvqBW/y6o5wsf3j19wTZ7S60TmtB5HoBhtgw7NKQRMWuz5vk2PR0CygUg==,
+      }
+    dev: false
 
   /public-encrypt/4.0.3:
     resolution:
@@ -6339,14 +6389,16 @@ packages:
       postcss-value-parser: 3.3.1
     dev: true
 
-  /refractor/3.4.0:
+  /refractor/4.1.1:
     resolution:
       {
-        integrity: sha512-dBeD02lC5eytm9Gld2Mx0cMcnR+zhSnsTfPpWqFaMgUMJfC9A6bcN3Br/NaXrnBJcuxnLFR90k1jrkaSyV8umg==,
+        integrity: sha512-9voyHtZDFp+eefstYM+ruonRfaYAUZxWOi8GCCXhz0b555qYy00qJLh3JbV5Du/vzmTpW7Tr/wvOJCVzIbHIxQ==,
       }
     dependencies:
-      hastscript: 6.0.0
-      parse-entities: 2.0.0
+      '@types/hast': 2.3.1
+      '@types/prismjs': 1.16.6
+      hastscript: 7.0.2
+      parse-entities: 3.0.0
       prismjs: 1.24.1
     dev: false
 
@@ -6396,6 +6448,18 @@ packages:
       hast-util-from-parse5: 6.0.1
       parse5: 6.0.1
     dev: true
+
+  /rehype-prism-plus/0.0.4:
+    resolution:
+      {
+        integrity: sha512-6QgqR1cZpaULPVea/9MHo6/M/35MWc4rEdqZVPAkb1bY2+BAqUqlvLGYjzPG5yRiRQvdJfumHzg3SkY+3fFFWA==,
+      }
+    dependencies:
+      hast-util-to-string: 1.0.4
+      parse-numeric-range: 1.2.0
+      refractor: 4.1.1
+      unist-util-visit: 3.1.0
+    dev: false
 
   /rehype-slug/4.0.1:
     resolution:
@@ -6805,6 +6869,14 @@ packages:
       {
         integrity: sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==,
       }
+    dev: true
+
+  /space-separated-tokens/2.0.1:
+    resolution:
+      {
+        integrity: sha512-ekwEbFp5aqSPKaqeY1PGrlGQxPNaq+Cnx4+bE2D8sciBQrHpbwoBbawqTN2+6jPs9IdWxxiUcN0K2pkczD3zmw==,
+      }
+    dev: false
 
   /spdx-correct/3.1.1:
     resolution:
@@ -7535,6 +7607,13 @@ packages:
         integrity: sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==,
       }
 
+  /unist-util-is/5.1.1:
+    resolution:
+      {
+        integrity: sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ==,
+      }
+    dev: false
+
   /unist-util-stringify-position/2.0.3:
     resolution:
       {
@@ -7554,6 +7633,16 @@ packages:
       unist-util-is: 4.1.0
     dev: false
 
+  /unist-util-visit-parents/4.1.1:
+    resolution:
+      {
+        integrity: sha512-1xAFJXAKpnnJl8G7K5KgU7FY55y3GcLIXqkzUj5QF/QVP7biUm0K0O2oqVkYsdjzJKifYeWn9+o6piAK2hGSHw==,
+      }
+    dependencies:
+      '@types/unist': 2.0.3
+      unist-util-is: 5.1.1
+    dev: false
+
   /unist-util-visit/2.0.3:
     resolution:
       {
@@ -7563,6 +7652,17 @@ packages:
       '@types/unist': 2.0.3
       unist-util-is: 4.1.0
       unist-util-visit-parents: 3.1.1
+    dev: false
+
+  /unist-util-visit/3.1.0:
+    resolution:
+      {
+        integrity: sha512-Szoh+R/Ll68QWAyQyZZpQzZQm2UPbxibDvaY8Xc9SUtYgPsDzx5AWSk++UUt2hJuow8mvwR+rG+LQLw+KsuAKA==,
+      }
+    dependencies:
+      '@types/unist': 2.0.3
+      unist-util-is: 5.1.1
+      unist-util-visit-parents: 4.1.1
     dev: false
 
   /universalify/0.1.2:

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -35,26 +35,6 @@ body {
   }
 }
 
-figure.kg-card.kg-code-card {
-  @apply flex flex-col-reverse;
-  figcaption {
-    @apply border-b border-brand leading-7 night-owl-theme px-6 py-4 rounded-tl-lg rounded-tr-lg;
-  }
-}
-
-figure.kg-card.kg-code-card > pre {
-  @apply mt-0 rounded-bl-lg rounded-br-lg rounded-tl-none rounded-tr-none;
-}
-
-figure.kg-card.kg-embed-card {
-  @apply flex items-center justify-center;
-
-  iframe {
-    @apply w-full;
-    height: 25rem;
-  }
-}
-
 .prose {
   @apply text-primary;
   a {
@@ -184,6 +164,43 @@ figure.kg-card.kg-embed-card {
       }
       @apply pl-0;
     }
+  }
+
+  // Custom CSS for GhostCMS generated HTML
+  figure.kg-card.kg-code-card {
+    @apply flex flex-col-reverse;
+    figcaption {
+      @apply border-b border-brand leading-7 night-owl-theme px-6 py-4 rounded-tl-lg rounded-tr-lg;
+    }
+  }
+
+  figure.kg-card.kg-code-card > pre {
+    @apply mt-0 rounded-bl-lg rounded-br-lg rounded-tl-none rounded-tr-none;
+  }
+
+  figure.kg-card.kg-embed-card {
+    @apply flex items-center justify-center;
+
+    iframe {
+      @apply w-full;
+      height: 25rem;
+    }
+  }
+
+  // Classes for 'rehype-prism-plug'
+  .code-line {
+    @apply border-brand border-l-4 -mx-4 pl-4;
+  }
+
+  .highlight-line {
+    @apply border-l-4 -mx-4;
+    background-color: rgba(55, 65, 81, 0.5);
+    border-left-color: rgb(59, 130, 246);
+  }
+
+  .line-number::before {
+    @apply -ml-2 pr-4 text-gray-light;
+    content: attr(line);
   }
 }
 

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -39,7 +39,7 @@ export const processGhostPageOrPost = async (
   const readingTime = (await import('reading-time')).default
   const rehype = (await import('rehype')).default
   const rehypeLink = (await import('rehype-autolink-headings')).default
-  const rehypePrism = (await import('@mapbox/rehype-prism')).default
+  const rehypePrism = (await import('rehype-prism-plus')).default
   const rehypeSlug = await import('rehype-slug')
   return await rehype()
     .data('settings', { fragment: true })
@@ -47,7 +47,7 @@ export const processGhostPageOrPost = async (
     .use(rehypeSlug)
     .use(rehypeLink)
     // @ts-ignore
-    .use(rehypePrism)
+    .use(rehypePrism, { showLineNumbers: true })
     .process(data.html!)
     .then(file => {
       const { text, words } = readingTime(file.contents as unknown as string)


### PR DESCRIPTION
## What does this PR do?

- replaces `@mapbox/rehype-prism` with `rehype-prism-plug`
- replaces `querystring` with `URLSearchParams`
- removes engines property from package.json